### PR TITLE
Fix links in category sections

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -34,7 +34,7 @@ layout: default
             {% for posts in category  %}
               {% for post in posts %}
                 {% if post.url %}
-                  <a href="{{ post.url }}" class="post-list-item">
+                  <a href="{{ post.url | prepend: site.baseurl }}" class="post-list-item">
                     <h2>
                     {{ post.title }}
                     </h2>


### PR DESCRIPTION
Jekyll is typically designed to work from: http://youraddress.com
In GitHub, projects instead work from: https://nihansultan.github.io and the name of the repository is added to the URL, making https://nihansultan.github.io/MBio_/ 

The name of the repository (`MBio_`) is made available to Jekyll through a variable called `site.baseurl`.
To fix the issue with your blog URLs this variable needs to be prepended. That is, if the URL is `/2021/05/12/myblog-post.html` prepending creates `/MBio_/2021/05/12/myblog-post.html`.

This was already done in line 23:
https://github.com/nihansultan/MBio_/blob/358fc0cbe58396797dadffc4af202fef3e4c66e6/_layouts/frontpage.html#L23
so we need only to replicate this and apply it to line 37:
https://github.com/nihansultan/MBio_/blob/358fc0cbe58396797dadffc4af202fef3e4c66e6/_layouts/frontpage.html#L37
where, as you can see, the `prepend: site.baseurl` instruction is absent.